### PR TITLE
Remove "?" behind CPU temp. if no core index found in sensors output

### DIFF
--- a/pve-mod-gui-temp.sh
+++ b/pve-mod-gui-temp.sh
@@ -225,10 +225,17 @@ function install_mod {
 					try {\n\
 						Object.keys(items[coreKey]).forEach((secondLevelKey) => {\n\
 							if (secondLevelKey.includes('_input')) {\n\
+								let tempStr = '';\n\
 								let temp = items[coreKey][secondLevelKey];\n\
 								let index = coreKey.match(/\\\S+\\\s*(\\\d+)/);\n\
-								index = (index !== null && index.length > 1) ? index[1] : '?';\n\
-								temps.push(\`\${cpuTempCaption}&nbsp;\${index}:&nbsp;\${temp}&deg;C\`);\n\
+								if(index !== null && index.length > 1) {\n\
+									index = index[1];\n\
+									tempStr = \`\${cpuTempCaption}&nbsp;\${index}:&nbsp;\${temp}&deg;C\`;\n\
+								}\n\
+								else {\n\
+									tempStr = \`\${cpuTempCaption}:&nbsp;\${temp}&deg;C\`;\n\
+								}\n\
+								temps.push(tempStr);\n\
 							}\n\
 						})\n\
 					} catch(e) { /*_*/ }\n\


### PR DESCRIPTION
A small clean-up for the CPU temperature display problem as seen in [issue](https://github.com/Meliox/PVE-mods/issues/11#issuecomment-1676257484).