### PR TITLE
Add support for multiple AMD temp types

### DIFF
--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -96,15 +96,28 @@ function configure {
 		if (echo "$sensorsOutput" | grep -q "$item"); then
 			case "$item" in
 				"coretemp-"*)
+					# Intel CPU
+					# Try to find temperature information				
 					CPU_ADDRESS_PREFIX=$item
 					CPU_ITEM_PREFIX="Core "
 					CPU_TEMP_CAPTION="Core"
 					break
 					;;
 				"k10temp-"*)
-					CPU_ADDRESS_PREFIX=$item
-					CPU_ITEM_PREFIX="Tccd"
-					CPU_TEMP_CAPTION="Temp"
+					# AMD CPU
+					# Try to find temperature information
+					if (echo "$sensorsOutput" | grep -A 2 "$item" | grep -q "Tctl"); then
+						CPU_ADDRESS_PREFIX=$item
+						CPU_ITEM_PREFIX="Tccd"
+						CPU_TEMP_CAPTION="Temp"
+					elif (echo "$sensorsOutput" | grep -A 2 "$item" | grep -q "Tccd"); then
+						CPU_ADDRESS_PREFIX=$item
+						CPU_ITEM_PREFIX="Tccd"
+						CPU_TEMP_CAPTION="Temp"					
+					else
+						CPU_ITEM_PREFIX="temp"
+						CPU_TEMP_CAPTION="Temp"
+					fi
 					break
 					;;
 				*)

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -86,6 +86,7 @@ function install_packages {
 function configure {
 	sensorsDetected=false
 	local sensorsOutput=$(sensors -j)
+
 	if [ $? -ne 0 ]; then
 		err "Sensor output error.\n\nCommand output:\n${sensorsOutput}\n\nExiting...\n"
 	fi
@@ -97,24 +98,26 @@ function configure {
 			case "$item" in
 				"coretemp-"*)
 					# Intel CPU
-					# Set temperature search criterias				
-					CPU_ADDRESS_PREFIX=$item
-					CPU_ITEM_PREFIX="Core "
-					CPU_TEMP_CAPTION="Core"
+					# Set temperature search criterias
+					if (echo "$sensorsOutput" | grep -A 10 "$item" | grep -q "Core "); then		
+						CPU_ADDRESS_PREFIX=$item
+						CPU_ITEM_PREFIX="Core "
+						CPU_TEMP_CAPTION="Core"
+					fi
 					break
 					;;
 				"k10temp-"*)
 					# AMD CPU
 					# Find and set temperature search criterias
-					if (echo "$sensorsOutput" | grep -A 2 "$item" | grep -q "Tctl"); then
+					if (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "Tctl"); then
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Tccd"
 						CPU_TEMP_CAPTION="Temp"
-					elif (echo "$sensorsOutput" | grep -A 2 "$item" | grep -q "Tccd"); then
+					elif (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "Tccd"); then
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Tccd"
 						CPU_TEMP_CAPTION="Temp"					
-					else
+					elif (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "temp"); then
 						CPU_ADDRESS_PREFIX=$item					
 						CPU_ITEM_PREFIX="temp"
 						CPU_TEMP_CAPTION="Temp"

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -124,14 +124,10 @@ function configure {
 				"k10temp-"*)
 					# AMD CPU
 					# Find and set temperature search criteria
-					if (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "Tctl"); then
+					if (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q -e "Tctl" -e "Tccd"); then
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Tccd"
-						CPU_TEMP_CAPTION="Temp"
-					elif (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "Tccd"); then
-						CPU_ADDRESS_PREFIX=$item
-						CPU_ITEM_PREFIX="Tccd"
-						CPU_TEMP_CAPTION="Temp"					
+						CPU_TEMP_CAPTION="Temp"			
 					elif (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "temp"); then
 						CPU_ADDRESS_PREFIX=$item					
 						CPU_ITEM_PREFIX="temp"

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -97,7 +97,7 @@ function configure {
 			case "$item" in
 				"coretemp-"*)
 					# Intel CPU
-					# Try to find temperature information				
+					# Set temperature search criterias				
 					CPU_ADDRESS_PREFIX=$item
 					CPU_ITEM_PREFIX="Core "
 					CPU_TEMP_CAPTION="Core"
@@ -105,7 +105,7 @@ function configure {
 					;;
 				"k10temp-"*)
 					# AMD CPU
-					# Try to find temperature information
+					# Find and set temperature search criterias
 					if (echo "$sensorsOutput" | grep -A 2 "$item" | grep -q "Tctl"); then
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Tccd"
@@ -115,6 +115,7 @@ function configure {
 						CPU_ITEM_PREFIX="Tccd"
 						CPU_TEMP_CAPTION="Temp"					
 					else
+						CPU_ADDRESS_PREFIX=$item					
 						CPU_ITEM_PREFIX="temp"
 						CPU_TEMP_CAPTION="Temp"
 					fi

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -98,7 +98,7 @@ function configure {
 			case "$item" in
 				"coretemp-"*)
 					# Intel CPU
-					# Set temperature search criterias
+					# Set temperature search criteria
 					if (echo "$sensorsOutput" | grep -A 10 "$item" | grep -q "Core "); then		
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Core "
@@ -108,7 +108,7 @@ function configure {
 					;;
 				"k10temp-"*)
 					# AMD CPU
-					# Find and set temperature search criterias
+					# Find and set temperature search criteria
 					if (echo "$sensorsOutput" | grep -A 4 "$item" | grep -q "Tctl"); then
 						CPU_ADDRESS_PREFIX=$item
 						CPU_ITEM_PREFIX="Tccd"


### PR DESCRIPTION
Fixes #48 
Changes add support for AMDs 2 temperature reporting variants (temp and Tccd). Example:

```
root@pve:~# sensors -j
{
   "fam15h_power-pci-00c4":{
      "Adapter": "PCI adapter",
      "power1":{
         "power1_average": 0.028,
         "power1_input": 0.033,
         "power1_crit": 15.000,
         "power1_average_interval": 0.010
      }
   },
   "amdgpu-pci-0008":{
      "Adapter": "PCI adapter",
      "vddgfx":{
         "in0_input": 0.887
      },
      "vddnb":{
         "in1_input": 0.887
      },
      "edge":{
         "temp1_input": 49.000
      }
   },
   "k10temp-pci-00c3":{
      "Adapter": "PCI adapter",
      "temp1":{
         "temp1_input": 49.250,
         "temp1_max": 70.000,
         "temp1_crit": 100.000,
         "temp1_crit_hyst": 99.000
      }
   }
}
```

```
{
   "asus_wmi_sensors-virtual-0":{
      "Adapter": "Virtual device",
      "CPU Core Voltage":{
         "in0_input": 0.970
      },
      "+12V Voltage":{
         "in1_input": 12.230
      },
      "+5V Voltage":{
         "in2_input": 4.960
      },
      "3VSB Voltage":{
         "in3_input": 3.314
      },
      "CPU Fan":{
         "fan1_input": 1451.000
      },
      "Chassis Fan 1":{
         "fan2_input": 1527.000
      },
      "Chassis Fan 2":{
         "fan3_input": 1486.000
      },
      "Chassis Fan 3":{
         "fan4_input": 1477.000
      },
      "AIO Pump":{
         "fan5_input": 0.000
      },
      "Water Pump":{
         "fan6_input": 0.000
      },
      "CPU OPT":{
         "fan7_input": 0.000
      },
      "CPU Temperature":{
         "temp1_input": 42.000
      },
      "Motherboard Temperature":{
         "temp2_input": 30.000
      },
      "Chipset Temperature":{
         "temp3_input": 44.000
      },
      "Tsensor 1 Temperature":{
         "temp4_input": 216.000
      }
   },
   "drivetemp-scsi-1-0":{
      "Adapter": "SCSI adapter",
      "temp1":{
         "temp1_input": 28.000
      }
   },
   "nvme-pci-0100":{
      "Adapter": "PCI adapter",
      "Composite":{
         "temp1_input": 37.850,
         "temp1_max": 83.850,
         "temp1_min": -5.150,
         "temp1_crit": 87.850,
         "temp1_alarm": 0.000
      }
   },
   "asusec-isa-0000":{
      "Adapter": "ISA adapter",
      "CPU Core":{
         "in0_input": 0.962
      },
      "CPU_Opt":{
         "fan1_input": 0.000
      },
      "Chipset":{
         "temp1_input": 44.000
      },
      "CPU":{
         "temp2_input": 42.000
      },
      "Motherboard":{
         "temp3_input": 30.000
      },
      "T_Sensor":{
         "temp4_input": -40.000
      },
      "VRM":{
         "temp5_input": 20.000
      },
      "CPU":{
         "curr1_input": 8.000
      }
   },
   "k10temp-pci-00c3":{
      "Adapter": "PCI adapter",
      "Tctl":{
         "temp1_input": 41.875
      },
      "Tccd1":{
         "temp3_input": 36.500
      }
   },
   "drivetemp-scsi-0-0":{
      "Adapter": "SCSI adapter",
      "temp1":{
         "temp1_input": 28.000
      }
   }
}
```


