### PR TITLE
Add Tdie entry for AMD CPUs

### DIFF
--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -488,14 +488,19 @@ Ext.define('PVE.mod.TempHelper', {\n\
 			if (cpuKeysA.length > 0) {\n\
 				let bTccd = false;\n\
 				let bTctl = false;\n\
+				let bTdie = false;\n\
 				cpuKeysA.forEach((cpuKey, cpuIndex) => {\n\
 					let items = objValue[cpuKey];\n\
 					bTccd = Object.keys(items).findIndex(item => { return String(item).startsWith('Tccd'); }) >= 0;\n\
 					bTctl = Object.keys(items).findIndex(item => { return String(item).startsWith('Tctl'); }) >= 0;\n\
+					bTdie = Object.keys(items).findIndex(item => { return String(item).startsWith('Tdie'); }) >= 0;\n\
 				});\n\
 				if (bTccd && bTctl && '$CPU_TEMP_TARGET' == 'Core') {\n\
 					AMDPackagePrefix = 'Tccd';\n\
 					AMDPackageCaption = 'Chiplet';\n\
+				} else if (bTdie) {\n\
+					AMDPackagePrefix = 'Tdie';\n\
+					AMDPackageCaption = 'Temp';\n\
 				} else if (bTctl) {\n\
 					AMDPackagePrefix = 'Tctl';\n\
 					AMDPackageCaption = 'Temp';\n\


### PR DESCRIPTION
I have a Ryzen 1600X on my Proxmox node, and the `lm-sensors` reports `Tctl` and `Tdie`. However, the `Tctl` is a control value for first gen Ryzen X and is offset by 20C. Since single-CCD processors won't have `Tccd` falling back to `Tctl` results in inaccurate value.

This PR adds a check for `Tdie` before `Tctl`. 
I am actually not sure if this is common in new gen Ryzen CPUs, but will help someone with an aging CPU like mine.