### PR TITLE
Add support for intel E and P cores

### DIFF
--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -543,12 +543,19 @@ Ext.define('PVE.mod.TempHelper', {\n\
 								tempStyle = 'color: red; font-weight: bold;';\n\
 							}\n\
 							let tempStr = '';\n\
-							let tempIndex = coreKey.match(/\\\S+\\\s*(\\\d+)/);\n\
+							let tempIndex = coreKey.match(\/(?:P\\\s+Core|E\\\s+Core|Core)\\\s*(\\\d+)\/);\n\
 							if (tempIndex !== null && tempIndex.length > 1) {\n\
 								tempIndex = tempIndex[1];\n\
-								tempStr = \`\${cpuTempCaption}&nbsp;\${tempIndex}:&nbsp;<span style=\"\${tempStyle}\">\${Ext.util.Format.number(tempVal, formatTemp)}\${cpuTempHelper.getUnit()}</span>\`;\n\
+								let coreType = coreKey.startsWith('P Core') ? 'P Core' :\n\
+											   coreKey.startsWith('E Core') ? 'E Core' :\n\
+											   cpuTempCaption;\n\
+								tempStr = \`\${coreType}&nbsp;\${tempIndex}:&nbsp;<span style=\"\${tempStyle}\">\${Ext.util.Format.number(tempVal, formatTemp)}\${cpuTempHelper.getUnit()}</span>\`;\n\
 							} else {\n\
-								tempStr = \`\${cpuTempCaption}:&nbsp;\${Ext.util.Format.number(tempVal, formatTemp)}\${cpuTempHelper.getUnit()}\`;\n\
+								// fallback for CPUs which do not have a core index\n\
+								let coreType = coreKey.startsWith('P Core') ? 'P Core' :\n\
+									coreKey.startsWith('E Core') ? 'E Core' :\n\
+									cpuTempCaption;\n\
+								tempStr = \`\${coreType}:&nbsp;<span style=\"\${tempStyle}\">\${Ext.util.Format.number(tempVal, formatTemp)}\${cpuTempHelper.getUnit()}</span>\`;\n\
 							}\n\
 							cpuTemps.push(tempStr);\n\
 						}\n\


### PR DESCRIPTION
fixes #100.

Tested against below data examples. All working well

```bash
{
   "nct6798-isa-0a20":{
      "Adapter": "ISA adapter",
      "fan1":{
         "fan1_input": 2319.000,
         "fan1_min": 0.000,
         "fan1_alarm": 0.000,
         "fan1_beep": 0.000,
         "fan1_pulses": 2.000
      },
      "fan2":{
         "fan2_input": 1914.000,
         "fan2_min": 0.000,
         "fan2_alarm": 0.000,
         "fan2_beep": 0.000,
         "fan2_pulses": 2.000
      },
      "vrm":{
         "temp2_input": 45.500,
         "temp2_max": 80.000,
         "temp2_max_hyst": 75.000,
         "temp2_crit": 95.000,
         "temp2_alarm": 0.000,
         "temp2_type": 4.000,
         "temp2_offset": 0.000,
         "temp2_beep": 0.000
      },
      "CPU":{
         "temp7_input": 49.000,
         "temp7_max": 80.000,
         "temp7_max_hyst": 75.000,
         "temp7_alarm": 0.000,
         "temp7_beep": 0.000
      },
      "PCH_CPU_TEMP":{
         "temp11_input": 0.000
      },
      "PCH_MCH_TEMP":{
         "temp12_input": 0.000
      },
      "beep_enable":{
         "beep_enable": 1.000
      }
   },
   "nvme-pci-5800":{
      "Adapter": "PCI adapter",
      "Composite":{
         "temp1_input": 40.850,
         "temp1_max": 82.850,
         "temp1_min": -0.150,
         "temp1_crit": 84.850,
         "temp1_alarm": 0.000
      },
      "Sensor 1":{
         "temp2_input": 40.850,
         "temp2_max": 65261.850,
         "temp2_min": -273.150
      }
   },
   "acpitz-acpi-0":{
      "Adapter": "ACPI interface",
      "temp1":{
         "temp1_input": 27.800
      }
   },
   "coretemp-isa-0000":{
      "Adapter": "ISA adapter",
      "6P 8E package":{
         "temp1_input": 45.000,
         "temp1_max": 100.000,
         "temp1_crit": 100.000,
         "temp1_crit_alarm": 0.000
      },
      "P Core 1":{
         "temp2_input": 44.000,
         "temp2_max": 100.000,
         "temp2_crit": 100.000,
         "temp2_crit_alarm": 0.000
      },
      "P Core 2":{
         "temp6_input": 43.000,
         "temp6_max": 100.000,
         "temp6_crit": 100.000,
         "temp6_crit_alarm": 0.000
      },
      "P Core 3":{
         "temp10_input": 47.000,
         "temp10_max": 100.000,
         "temp10_crit": 100.000,
         "temp10_crit_alarm": 0.000
      },
      "P Core 4":{
         "temp14_input": 41.000,
         "temp14_max": 100.000,
         "temp14_crit": 100.000,
         "temp14_crit_alarm": 0.000
      },
      "P Core 5":{
         "temp18_input": 43.000,
         "temp18_max": 100.000,
         "temp18_crit": 100.000,
         "temp18_crit_alarm": 0.000
      },
      "P Core 6":{
         "temp22_input": 43.000,
         "temp22_max": 100.000,
         "temp22_crit": 100.000,
         "temp22_crit_alarm": 0.000
      },
      "E Core 1":{
         "temp26_input": 44.000,
         "temp26_max": 100.000,
         "temp26_crit": 100.000,
         "temp26_crit_alarm": 0.000
      },
      "E Core 2":{
         "temp27_input": 44.000,
         "temp27_max": 100.000,
         "temp27_crit": 100.000,
         "temp27_crit_alarm": 0.000
      },
      "E Core 3":{
         "temp28_input": 44.000,
         "temp28_max": 100.000,
         "temp28_crit": 100.000,
         "temp28_crit_alarm": 0.000
      },
      "E Core 4":{
         "temp29_input": 44.000,
         "temp29_max": 100.000,
         "temp29_crit": 100.000,
         "temp29_crit_alarm": 0.000
      },
      "E Core 5":{
         "temp30_input": 40.000,
         "temp30_max": 100.000,
         "temp30_crit": 100.000,
         "temp30_crit_alarm": 0.000
      },
      "E Core 6":{
         "temp31_input": 40.000,
         "temp31_max": 100.000,
         "temp31_crit": 100.000,
         "temp31_crit_alarm": 0.000
      },
      "E Core 7":{
         "temp32_input": 40.000,
         "temp32_max": 100.000,
         "temp32_crit": 100.000,
         "temp32_crit_alarm": 0.000
      },
      "E Core 8":{
         "temp33_input": 41.000,
         "temp33_max": 100.000,
         "temp33_crit": 100.000,
         "temp33_crit_alarm": 0.000
      }
   },
   "nvme-pci-0100":{
      "Adapter": "PCI adapter",
      "Composite":{
         "temp1_input": 41.850,
         "temp1_max": 89.850,
         "temp1_min": -273.150,
         "temp1_crit": 94.850,
         "temp1_alarm": 0.000
      },
      "Sensor 1":{
         "temp2_input": 41.850,
         "temp2_max": 65261.850,
         "temp2_min": -273.150
      },
      "Sensor 2":{
         "temp3_input": 45.850,
         "temp3_max": 65261.850,
         "temp3_min": -273.150
      }
   }
}
```


```bash
{
    "spd5118-i2c-0-50": {
        "Adapter": "SMBus I801 adapter at efa0",
        "temp1": {
            "temp1_input": 40.0,
            "temp1_max": 55.0,
            "temp1_min": 0.0,
            "temp1_crit": 85.0,
            "temp1_lcrit": 0.0,
            "temp1_min_alarm": 0.0,
            "temp1_crit_alarm": 0.0,
            "temp1_lcrit_alarm": 0.0
        }
    },
    "coretemp-isa-0000": {
        "Adapter": "ISA adapter",
        "Package id 0": {
            "temp1_input": 38.0,
            "temp1_max": 105.0,
            "temp1_crit": 105.0,
            "temp1_crit_alarm": 0.0
        },
        "Core 0": {
            "temp2_input": 37.0,
            "temp2_max": 105.0,
            "temp2_crit": 105.0,
            "temp2_crit_alarm": 0.0
        },
        "Core 1": {
            "temp3_input": 37.0,
            "temp3_max": 105.0,
            "temp3_crit": 105.0,
            "temp3_crit_alarm": 0.0
        },
        "Core 2": {
            "temp4_input": 37.0,
            "temp4_max": 105.0,
            "temp4_crit": 105.0,
            "temp4_crit_alarm": 0.0
        },
        "Core 3": {
            "temp5_input": 37.0,
            "temp5_max": 105.0,
            "temp5_crit": 105.0,
            "temp5_crit_alarm": 0.0
        },
        "Core 4": {
            "temp6_input": 38.0,
            "temp6_max": 105.0,
            "temp6_crit": 105.0,
            "temp6_crit_alarm": 0.0
        },
        "Core 5": {
            "temp7_input": 37.0,
            "temp7_max": 105.0,
            "temp7_crit": 105.0,
            "temp7_crit_alarm": 0.0
        },
        "Core 6": {
            "temp8_input": 37.0,
            "temp8_max": 105.0,
            "temp8_crit": 105.0,
            "temp8_crit_alarm": 0.0
        },
        "Core 7": {
            "temp9_input": 37.0,
            "temp9_max": 105.0,
            "temp9_crit": 105.0,
            "temp9_crit_alarm": 0.0
        }
    },
    "acpitz-acpi-0": {
        "Adapter": "ACPI interface",
        "temp1": {
            "temp1_input": 27.8
        }
    },
    "it8620-isa-0a20": {
        "Adapter": "ISA adapter",
        "in0": {
            "in0_input": 0.768,
            "in0_min": 0.504,
            "in0_max": 0.504,
            "in0_alarm": 1.0,
            "in0_beep": 0.0
        },
        "in1": {
            "in1_input": 1.212,
            "in1_min": 1.536,
            "in1_max": 0.384,
            "in1_alarm": 1.0,
            "in1_beep": 0.0
        },
        "in2": {
            "in2_input": 2.148,
            "in2_min": 2.7,
            "in2_max": 2.436,
            "in2_alarm": 1.0,
            "in2_beep": 0.0
        },
        "+5V": {
            "in3_input": 4.32,
            "in3_min": 4.944,
            "in3_max": 0.384,
            "in3_alarm": 1.0,
            "in3_beep": 0.0
        },
        "in4": {
            "in4_input": 2.16,
            "in4_min": 0.276,
            "in4_max": 2.604,
            "in4_alarm": 0.0,
            "in4_beep": 0.0
        },
        "in5": {
            "in5_input": 2.16,
            "in5_min": 0.876,
            "in5_max": 1.92,
            "in5_alarm": 1.0,
            "in5_beep": 0.0
        },
        "in6": {
            "in6_input": 2.172,
            "in6_min": 1.932,
            "in6_max": 1.74,
            "in6_alarm": 1.0,
            "in6_beep": 0.0
        },
        "3VSB": {
            "in7_input": 3.456,
            "in7_min": 3.072,
            "in7_max": 0.144,
            "in7_alarm": 1.0,
            "in7_beep": 0.0
        },
        "Vbat": {
            "in8_input": 3.312
        },
        "fan2": {
            "fan2_input": 2129.0,
            "fan2_min": 14.0,
            "fan2_alarm": 0.0,
            "fan2_beep": 0.0
        },
        "fan3": {
            "fan3_input": 791.0,
            "fan3_min": 12.0,
            "fan3_alarm": 0.0,
            "fan3_beep": 0.0
        },
        "temp1": {
            "temp1_input": -128.0,
            "temp1_max": -103.0,
            "temp1_min": -17.0,
            "temp1_alarm": 0.0,
            "temp1_offset": 0.0,
            "temp1_beep": 0.0
        },
        "temp2": {
            "temp2_input": 34.0,
            "temp2_max": -23.0,
            "temp2_min": 76.0,
            "temp2_alarm": 1.0,
            "temp2_type": 4.0,
            "temp2_offset": 100.0,
            "temp2_beep": 0.0
        },
        "temp3": {
            "temp3_input": -128.0,
            "temp3_max": 8.0,
            "temp3_min": 26.0,
            "temp3_alarm": 0.0,
            "temp3_offset": 0.0,
            "temp3_beep": 0.0
        },
        "temp4": {
            "temp4_input": 0.0
        },
        "temp5": {
            "temp5_input": -128.0
        },
        "temp6": {
            "temp6_input": -128.0
        },
        "pwm1": {
            "pwm1": 63.5,
            "pwm1_freq": 23437.0,
            "pwm1_enable": 0.0
        },
        "pwm2": {
            "pwm2": 63.5,
            "pwm2_freq": 23437.0,
            "pwm2_enable": 0.0
        },
        "pwm3": {
            "pwm3": 63.5,
            "pwm3_freq": 23437.0,
            "pwm3_enable": 0.0
        },
        "pwm4": {
            "pwm4": 0.0,
            "pwm4_freq": 23437.0,
            "pwm4_enable": 1.0
        },
        "pwm5": {
            "pwm5": 30.0,
            "pwm5_freq": 23437.0,
            "pwm5_enable": 1.0
        },
        "intrusion0": {
            "intrusion0_alarm": 1.0
        }
    },
    "nvme-pci-0500": {
        "Adapter": "PCI adapter",
        "Composite": {
            "temp1_input": 39.85,
            "temp1_max": 74.85,
            "temp1_min": -20.15,
            "temp1_crit": 79.85,
            "temp1_alarm": 0.0
        }
    }
}
```


```bash
{
   "asus_wmi_sensors-virtual-0":{
      "Adapter": "Virtual device",
      "CPU Core Voltage":{
         "in0_input": 0.970
      },
      "+12V Voltage":{
         "in1_input": 12.230
      },
      "+5V Voltage":{
         "in2_input": 4.960
      },
      "3VSB Voltage":{
         "in3_input": 3.314
      },
      "CPU Fan":{
         "fan1_input": 1451.000
      },
      "Chassis Fan 1":{
         "fan2_input": 1527.000
      },
      "Chassis Fan 2":{
         "fan3_input": 1486.000
      },
      "Chassis Fan 3":{
         "fan4_input": 1477.000
      },
      "AIO Pump":{
         "fan5_input": 0.000
      },
      "Water Pump":{
         "fan6_input": 0.000
      },
      "CPU OPT":{
         "fan7_input": 0.000
      },
      "CPU Temperature":{
         "temp1_input": 42.000
      },
      "Motherboard Temperature":{
         "temp2_input": 30.000
      },
      "Chipset Temperature":{
         "temp3_input": 44.000
      },
      "Tsensor 1 Temperature":{
         "temp4_input": 216.000
      }
   },
   "drivetemp-scsi-1-0":{
      "Adapter": "SCSI adapter",
      "temp1":{
         "temp1_input": 28.000
      }
   },
   "nvme-pci-0100":{
      "Adapter": "PCI adapter",
      "Composite":{
         "temp1_input": 37.850,
         "temp1_max": 83.850,
         "temp1_min": -5.150,
         "temp1_crit": 87.850,
         "temp1_alarm": 0.000
      }
   },
   "asusec-isa-0000":{
      "Adapter": "ISA adapter",
      "CPU Core":{
         "in0_input": 0.962
      },
      "CPU_Opt":{
         "fan1_input": 0.000
      },
      "Chipset":{
         "temp1_input": 44.000
      },
      "CPU":{
         "temp2_input": 42.000
      },
      "Motherboard":{
         "temp3_input": 30.000
      },
      "T_Sensor":{
         "temp4_input": -40.000
      },
      "VRM":{
         "temp5_input": 20.000
      },
      "CPU":{
         "curr1_input": 8.000
      }
   },
   "k10temp-pci-00c3":{
      "Adapter": "PCI adapter",
      "Tctl":{
         "temp1_input": 41.875
      },
      "Tccd1":{
         "temp3_input": 36.500
      }
   },
   "drivetemp-scsi-0-0":{
      "Adapter": "SCSI adapter",
      "temp1":{
         "temp1_input": 28.000
      }
   }
}
```