### PR TITLE
Fix duplicate sodimm fan keys dectection, setup and visualisation

### DIFF
--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -121,7 +121,8 @@ function configure {
     SENSORS_DETECTED=false
     local sensorsOutput
 
-	# Collect lm-sensors output
+	#### Collect lm-sensors output ####
+	#region sensors collection
 	if [ "$DEBUG_REMOTE" = true ]; then
 		warn "Remote debugging is used. Sensor readings from dump file $DEBUG_JSON_FILE will be used."
 		warn "Remote debugging is used. UPS readings from dump file $DEBUG_UPS_FILE will be used."
@@ -136,6 +137,7 @@ function configure {
     if [ $? -ne 0 ]; then
         err "Sensor output error.\n\nCommand output:\n${sensorsOutput}\n\nExiting..."
     fi
+	#endregion sensors collection
 
 	#### CPU ####
 	#region cpu setup
@@ -360,9 +362,11 @@ function configure {
 	#endregion system info setup
 
     #### Final Check ####
+	#region final check
     if [ "$SENSORS_DETECTED" = false ] && [ "$ENABLE_UPS" = false ] && [ "$ENABLE_SYSTEM_INFO" = false ]; then
         err "No sensors detected, UPS or system info enabled. Exiting."
     fi
+	#endregion final check
 }
 
 

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -138,6 +138,7 @@ function configure {
     fi
 
 	#### CPU ####
+	#region cpu setup
 	msgb "\n=== Detecting CPU temperature sensors ==="
 	ENABLE_CPU=false
 	local cpuList=""
@@ -185,16 +186,13 @@ function configure {
 	else
 		warn "No CPU temperature sensors found."
 	fi
+	#endregion cpu setup
 
 	#### RAM ####
+	#region ram setup
 	msgb "\n=== Detecting RAM temperature sensors ==="
 	local ramList=$(echo "$sensorsOutput" | grep -o '"SODIMM[^"]*"' | sed 's/"//g' | paste -sd, -)
 	local ramCount=$(echo "$ramList" | tr ',' '\n' | wc -l)
-
-	# Clean up if no RAM found
-	if [ -z "$ramList" ]; then
-		ramCount=0
-	fi
 
 	if [ "$ramCount" -gt 0 ]; then
 		info "Detected RAM sensors ($ramCount): $ramList"
@@ -204,8 +202,10 @@ function configure {
 		warn "No RAM temperature sensors found."
 		ENABLE_RAM_TEMP=false
 	fi
+	#endregion ram setup
 
     #### HDD/SSD ####
+	#region hdd setup
     msgb "\n=== Detecting HDD/SSD temperature sensors ==="
     local hddList=($(echo "$sensorsOutput" | grep -o '"drivetemp-scsi[^"]*"' | sed 's/"//g'))
     if [ ${#hddList[@]} -gt 0 ]; then
@@ -216,8 +216,10 @@ function configure {
         warn "No HDD/SSD temperature sensors found."
         ENABLE_HDD_TEMP=false
     fi
+	#endregion hdd setup
 
     #### NVMe ####
+	#region nvme setup
     msgb "\n=== Detecting NVMe temperature sensors ==="
     local nvmeList=($(echo "$sensorsOutput" | grep -o '"nvme[^"]*"' | sed 's/"//g'))
     if [ ${#nvmeList[@]} -gt 0 ]; then
@@ -228,8 +230,10 @@ function configure {
         warn "No NVMe temperature sensors found."
         ENABLE_NVME_TEMP=false
     fi
+	#endregion nvme setup
 
 	#### Fans ####
+	#region fan setup
 	msgb "\n=== Detecting fan speed sensors ==="
 
 	local fanList=""
@@ -264,8 +268,10 @@ function configure {
 		warn "No fan speed sensors found."
 		ENABLE_FAN_SPEED=false
 	fi
+	#endregion fan setup
 
     #### Temperature Units ####
+	#region temp unit setup
     if [ "$SENSORS_DETECTED" = true ]; then
         local unit=$(ask "Display temperatures in Celsius [C] or Fahrenheit [f]? (C/f)")
         case "$unit" in
@@ -283,8 +289,10 @@ function configure {
                 ;;
         esac
     fi
+	#endregion temp unit setup
 
     #### UPS ####
+	#region ups setup
     local choiceUPS=$(ask "Enable UPS information? (y/N)")
     case "$choiceUPS" in
         [yY])
@@ -318,8 +326,10 @@ function configure {
             ENABLE_UPS=false
             ;;
     esac
+	#endregion ups setup
 
     #### System Info ####
+	#region system info setup
     msgb "\n=== Detecting System Information ==="
     for i in 1 2; do
         echo "type ${i})"
@@ -347,6 +357,7 @@ function configure {
             SYSTEM_INFO_TYPE=1
             ;;
     esac
+	#endregion system info setup
 
     #### Final Check ####
     if [ "$SENSORS_DETECTED" = false ] && [ "$ENABLE_UPS" = false ] && [ "$ENABLE_SYSTEM_INFO" = false ]; then

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -425,7 +425,7 @@ collect_sensors_output() {
 		# Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM3":{"temp3_input":34.0}\
 		$res->{sensorsOutput} =~ s/\\"SODIMM\\":\\{\\"temp(\\d+)_input\\"/\\"SODIMM$1\\":\\{\\"temp$1_input\\"/g;\
 		\
-		# Fix duplicate fans keys by appending fan number with a space\
+		# Fix duplicate fans keys by appending fan number\
 		# Example: "Processor Fan":{"fan2_input":1000,...} → "Processor Fan 2":{"fan2_input":1000,...}\
 		$res->{sensorsOutput} =~ s/\\"([^"]+)\\":\\{\\"fan(\\d+)_input\\"/\\"$1 $2\\":\{\\"fan$2_input\\"/g;\
 	' "$NODES_PM_FILE"

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -25,7 +25,7 @@ BACKUP_DIR=""
 
 # DEV NOTE: lm-sensors version >3.6.0 breakes properly formatted JSON output using 'sensors -j'. This implements a workaround using uses a python3 for formatting
 
-DEBUG_REMOTE=true
+DEBUG_REMOTE=false
 DEBUG_JSON_FILE="/tmp/sensordata.json"
 DEBUG_UPS_FILE="/tmp/upsc.txt"
 

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -406,7 +406,6 @@ collect_sensors_output() {
     fi
 	#region sensors heredoc
 	sed -i '/my \$dinfo = df('\''\/'\'', 1);/i\
-		\
 		# Collect sensor data from lm-sensors\
 		$res->{sensorsOutput} = `'"$sensorsCmd"'`;\
 		\
@@ -425,6 +424,10 @@ collect_sensors_output() {
 		# This prevents JSON key overwrites when multiple SODIMM sensors exist\
 		# Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM3":{"temp3_input":34.0}\
 		$res->{sensorsOutput} =~ s/\\"SODIMM\\":\\{\\"temp(\\d+)_input\\"/\\"SODIMM$1\\":\\{\\"temp$1_input\\"/g;\
+		\
+		# Fix duplicate fans keys by appending fan number with a space\
+		# Example: "Processor Fan":{"fan2_input":1000,...} → "Processor Fan 2":{"fan2_input":1000,...}\
+		$res->{sensorsOutput} =~ s/\\"([^"]+)\\":\\{\\"fan(\\d+)_input\\"/\\"$1 $2\\":\{\\"fan$2_input\\"/g;\
 	' "$NODES_PM_FILE"
 	#endregion sensors heredoc
     info "Sensors' retriever added to \"$output_file\"."

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -280,6 +280,7 @@ function configure {
 
     #### Temperature Units ####
 	#region temp unit setup
+	msgb "\n=== Display temperature ==="
     if [ "$SENSORS_DETECTED" = true ]; then
         local unit=$(ask "Display temperatures in Celsius [C] or Fahrenheit [f]? (C/f)")
         case "$unit" in

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -506,7 +506,7 @@ collect_sensors_output() {
 		# Replace NaN values with null for valid JSON\
 		$res->{sensorsOutput} =~ s/\\bNaN\\b/null/g;\
 		\
-        # Fix duplicate SODIMM keys by appending fan number with a space - handle both pretty and one-line JSON\
+        # Fix duplicate SODIMM keys by appending temperature sensor number with a space - handle both pretty and one-line JSON\
 		# Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM 3":{"temp3_input":34.0}\
         $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {\\n  "temp$1_input"/g;\
 		\

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -508,7 +508,7 @@ collect_sensors_output() {
 		\
         # Fix duplicate SODIMM keys by appending fan number with a space - handle both pretty and one-line JSON\
 		# Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM 3":{"temp3_input":34.0}\
-        $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {<\n  "temp$1_input"/g;\
+        $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {\\n  "temp$1_input"/g;\
 		\
 		# Fix duplicate fans keys by appending fan number with a space - handle both pretty and one-line JSON\
 		# Example: "Processor Fan":{"fan2_input":1000,...} → "Processor Fan 2":{"fan2_input":1000,...}\

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -200,7 +200,7 @@ function configure {
 	#region ram setup
 	msgb "\n=== Detecting RAM temperature sensors ==="
 	local ramList=$(echo "$sanitisedSensorsOutput" | grep -o '"SODIMM[^"]*"' | sed 's/"//g' | paste -sd, -)
-	local ramCount=$(echo "$ramList" | tr ',' '\n' | wc -l)
+	local ramCount=$(grep -c '"SODIMM[^"]*"' <<<"$sanitisedSensorsOutput")
 
 	if [ "$ramCount" -gt 0 ]; then
 		info "Detected RAM sensors ($ramCount): $ramList"
@@ -249,7 +249,7 @@ function configure {
 
 	# Find all fan names that have fan*_input entries
 	fanList=$(echo "$sanitisedSensorsOutput" | grep -B2 '"fan[0-9]\+_input"' | grep '".*": {' | sed 's/.*"\([^"]*\)": {.*/\1/' | sort -u | paste -sd, -)
-	fanCount=$(echo "$fanList" | tr ',' '\n' | wc -l)
+	fanCount=$(grep -c 'fan[0-9]\+_input' <<<"$sanitisedSensorsOutput")
 
 	if [ "$fanCount" -gt 0 ]; then
 		info "Detected fan speed sensors ($fanCount): $fanList"

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -120,6 +120,12 @@ function install_packages {
 function configure {
     SENSORS_DETECTED=false
     local sensorsOutput
+	local sanitisedSensorsOutput
+	local upsOutput
+	local modelName
+	local upsConnection
+
+	install_packages
 
 	#### Collect lm-sensors output ####
 	#region sensors collection
@@ -132,12 +138,10 @@ function configure {
 	fi
 
 	# Apply lm-sensors sanitization
-	sensorsOutput=$(sanitize_sensors_output "$sensorsOutput")
-
-	echo $sensorsOutput
+	sanitisedSensorsOutput=$(sanitize_sensors_output "$sensorsOutput")
 
     if [ $? -ne 0 ]; then
-        err "Sensor output error.\n\nCommand output:\n${sensorsOutput}\n\nExiting..."
+        err "Sensor output error.\n\nCommand output:\n${sanitisedSensorsOutput}\n\nExiting..."
     fi
 	#endregion sensors collection
 
@@ -150,7 +154,7 @@ function configure {
 
 	# Find all CPU sensors that match known patterns
 	for pattern in "${KNOWN_CPU_SENSORS[@]}"; do
-		found_sensors=$(echo "$sensorsOutput" | grep -o "\"${pattern}[^\"]*\"" | sed 's/"//g')
+		found_sensors=$(echo "$sanitisedSensorsOutput" | grep -o "\"${pattern}[^\"]*\"" | sed 's/"//g')
 		if [ -n "$found_sensors" ]; then
 			while read -r sensor; do
 				if [ -n "$sensor" ]; then
@@ -195,7 +199,7 @@ function configure {
 	#### RAM ####
 	#region ram setup
 	msgb "\n=== Detecting RAM temperature sensors ==="
-	local ramList=$(echo "$sensorsOutput" | grep -o '"SODIMM[^"]*"' | sed 's/"//g' | paste -sd, -)
+	local ramList=$(echo "$sanitisedSensorsOutput" | grep -o '"SODIMM[^"]*"' | sed 's/"//g' | paste -sd, -)
 	local ramCount=$(echo "$ramList" | tr ',' '\n' | wc -l)
 
 	if [ "$ramCount" -gt 0 ]; then
@@ -211,7 +215,7 @@ function configure {
     #### HDD/SSD ####
 	#region hdd setup
     msgb "\n=== Detecting HDD/SSD temperature sensors ==="
-    local hddList=($(echo "$sensorsOutput" | grep -o '"drivetemp-scsi[^"]*"' | sed 's/"//g'))
+    local hddList=($(echo "$sanitisedSensorsOutput" | grep -o '"drivetemp-scsi[^"]*"' | sed 's/"//g'))
     if [ ${#hddList[@]} -gt 0 ]; then
         info "Detected HDD/SSD sensors (${#hddList[@]}): $(IFS=,; echo "${hddList[*]}")"
         ENABLE_HDD_TEMP=true
@@ -225,7 +229,7 @@ function configure {
     #### NVMe ####
 	#region nvme setup
     msgb "\n=== Detecting NVMe temperature sensors ==="
-    local nvmeList=($(echo "$sensorsOutput" | grep -o '"nvme[^"]*"' | sed 's/"//g'))
+    local nvmeList=($(echo "$sanitisedSensorsOutput" | grep -o '"nvme[^"]*"' | sed 's/"//g'))
     if [ ${#nvmeList[@]} -gt 0 ]; then
         info "Detected NVMe sensors (${#nvmeList[@]}): $(IFS=,; echo "${nvmeList[*]}")"
         ENABLE_NVME_TEMP=true
@@ -244,7 +248,7 @@ function configure {
 	local fanCount=0
 
 	# Find all fan names that have fan*_input entries
-	fanList=$(echo "$sensorsOutput" | grep -B2 '"fan[0-9]\+_input"' | grep '".*": {' | sed 's/.*"\([^"]*\)": {.*/\1/' | sort -u | paste -sd, -)
+	fanList=$(echo "$sanitisedSensorsOutput" | grep -B2 '"fan[0-9]\+_input"' | grep '".*": {' | sed 's/.*"\([^"]*\)": {.*/\1/' | sort -u | paste -sd, -)
 	fanCount=$(echo "$fanList" | tr ',' '\n' | wc -l)
 
 	if [ "$fanCount" -gt 0 ]; then

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -506,11 +506,11 @@ collect_sensors_output() {
 		# Replace NaN values with null for valid JSON\
 		$res->{sensorsOutput} =~ s/\\bNaN\\b/null/g;\
 		\
-        # Fix duplicate SODIMM keys by appending temperature sensor number\
-        # Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM 3":{"temp3_input":34.0}\
-        $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {\\n  "temp$1_input"/g;\
+        # Fix duplicate SODIMM keys by appending fan number with a space - handle both pretty and one-line JSON\
+		# Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM 3":{"temp3_input":34.0}\
+        $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {<\n  "temp$1_input"/g;\
 		\
-		# Fix duplicate fans keys by appending fan number with a space\
+		# Fix duplicate fans keys by appending fan number with a space - handle both pretty and one-line JSON\
 		# Example: "Processor Fan":{"fan2_input":1000,...} → "Processor Fan 2":{"fan2_input":1000,...}\
 		$res->{sensorsOutput} =~ s/"([^"]+)"\\s*:\\s*\{\\s*"fan(\\d+)_input"/"$1 $2": {\\n  "fan$2_input"/g;\
 		\

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -134,6 +134,8 @@ function configure {
 	# Apply lm-sensors sanitization
 	sensorsOutput=$(sanitize_sensors_output "$sensorsOutput")
 
+	echo $sensorsOutput
+
     if [ $? -ne 0 ]; then
         err "Sensor output error.\n\nCommand output:\n${sensorsOutput}\n\nExiting..."
     fi
@@ -1625,7 +1627,13 @@ function save_sensors_data {
 		local choiceContinue=$(ask "Do you wish to continue? (Y/n)")
 		case "$choiceContinue" in
 			[yY]|"")
-				sensors -j 2>/dev/null | python3 -m json.tool >"$filepath"
+				echo "lm-sensors raw output:" >"$filepath"
+				sensorsOutput=$(sensors -j 2>/dev/null)
+				echo "$sensorsOutput" >>"$filepath"
+				echo -e "\n\nSanitised lm-sensors output:" >>"$filepath"
+				# Apply lm-sensors sanitization
+				sanitisedSensorsOutput=$(sanitize_sensors_output "$sensorsOutput")
+				echo "$sanitisedSensorsOutput" >>"$filepath"
 				info "Sensors data saved in $filepath."
 				;;
 			*)

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -431,7 +431,12 @@ function install_mod {
 sanitize_sensors_output() {
     local input="$1"
 
-    echo "$input" | perl -pe '
+    # Pipe the text into Perl:
+    #   -0777  → "slurp mode": read the entire stream as one string so
+    #            regexes can match across line breaks.
+    #   -pe    → loop over input, applying the script (-e) and printing.
+	# Apply python3 json.tool for proper formatting and validation
+    echo "$input" | perl -0777 -pe '
         # Replace ERROR lines with placeholder values
         s/ERROR:.+\s(\w+):\s(.+)/"$1": 0.000,/g;
         s/ERROR:.+\s(\w+)!/"$1": 0.000,/g;
@@ -442,11 +447,11 @@ sanitize_sensors_output() {
         # Replace NaN values with null
         s/\bNaN\b/null/g;
 
-        # Fix duplicate SODIMM keys
-        s/"SODIMM":\{"temp(\d+)_input"/"SODIMM $1":\{"temp$1_input"/g;
+        # Fix duplicate SODIMM keys - handle both pretty and one-line JSON  
+        s/"SODIMM"\s*:\s*\{\s*"temp(\d+)_input"/"SODIMM $1": {\n  "temp$1_input"/g;
 
-        # Fix duplicate fan keys
-        s/"([^"]+)":\{"fan(\d+)_input"/"$1 $2":\{"fan$2_input"/g;
+        # Fix duplicate fan keys - handle both pretty and one-line JSON
+        s/"([^"]*Fan[^"]*)"\s*:\s*\{\s*"fan(\d+)_input"/"$1 $2": {\n  "fan$2_input"/g;
     ' | python3 -m json.tool 2>/dev/null || echo "$input"
 }
 
@@ -497,11 +502,11 @@ collect_sensors_output() {
 		\
         # Fix duplicate SODIMM keys by appending temperature sensor number\
         # Example: "SODIMM":{"temp3_input":34.0} becomes "SODIMM 3":{"temp3_input":34.0}\
-        $res->{sensorsOutput} =~ s/\\"SODIMM\":\\{\\"temp(\\d+)_input\\"/\\"SODIMM $1\\":\{\\"temp$1_input\\"/g;\
+        $res->{sensorsOutput} =~ s/"SODIMM"\\s*:\\s*\\{\\s*"temp(\\d+)_input"/"SODIMM $1": {\\n  "temp$1_input"/g;\
 		\
 		# Fix duplicate fans keys by appending fan number with a space\
 		# Example: "Processor Fan":{"fan2_input":1000,...} → "Processor Fan 2":{"fan2_input":1000,...}\
-		$res->{sensorsOutput} =~ s/\\"([^"]+)\\":\\{\\"fan(\\d+)_input\\"/\\"$1 $2\\":\{\\"fan$2_input\\"/g;\
+		$res->{sensorsOutput} =~ s/"([^"]+)"\\s*:\\s*\{\\s*"fan(\\d+)_input"/"$1 $2": {\\n  "fan$2_input"/g;\
 		\
 		# Format JSON output properly (workaround for lm-sensors >3.6.0 issues)\
 		$res->{sensorsOutput} =~ /^(.*)$/s;\


### PR DESCRIPTION
Properly fix #133, fix #113, fix #136 (false detection of fans)
<img width="1174" height="619" alt="image" src="https://github.com/user-attachments/assets/6856fdf4-2b4c-4e76-b83f-5556e98cbf52" />

Also install shows properly. Same sanitiser as node.pm is applied to lm-sensors output during install.
```bash
root@pve:~# bash pve-mod-gui-sensors.sh install

Installing the Proxmox VE sensors display mod...

=== Preparing mod installation ===
[info] Root privileges verified.
[warning] Remote debugging is used. Sensor readings from dump file /tmp/sensordata.json will be used.
[warning] Remote debugging is used. UPS readings from dump file /tmp/upsc.txt will be used.

=== Detecting CPU temperature sensors ===
[info] Detected CPU sensors (2): coretemp-isa-0000,coretemp-isa-0001

Display temperatures for all cores [C] or average per CPU [a] (some newer AMD variants support per die)? (C/a):
[info] Temperatures will be displayed for all cores.

=== Detecting RAM temperature sensors ===
[info] Detected RAM sensors (4): SODIMM 3,SODIMM 4,SODIMM 5,SODIMM 6

=== Detecting HDD/SSD temperature sensors ===
[warning] No HDD/SSD temperature sensors found.

=== Detecting NVMe temperature sensors ===
[warning] No NVMe temperature sensors found.

=== Detecting fan speed sensors ===
[info] Detected fan speed sensors (4): Other Fan 3,Other Fan 4,Processor Fan 1,Processor Fan 2

Display fans reporting zero speed? (Y/n):
[info] Zero-speed fans will be displayed.

Display temperatures in Celsius [C] or Fahrenheit [f]? (C/f):
[info] Using Celsius.

Enable UPS information? (y/N): y
[info] Remote debugging: UPS readings from /tmp/upsc.txt
[info] Connected to UPS model: Back-UPS BX500MI at DEBUG_UPS.

=== Detecting System Information ===
type 1)
        Manufacturer: QEMU
        Product Name: Standard PC (i440FX + PIIX, 1996)
        Serial Number: Not Specified
type 2)

Enable system information? (1/2/n):
[info] System information will be displayed.

=== Creating backups of modified files ===
[info] Using default backup directory: /root/PVE-MODS
[info] Backup directory already exists: /root/PVE-MODS
[info] Created backup: /root/PVE-MODS/Nodes.pm.20250909_204604
[info] Created backup: /root/PVE-MODS/pvemanagerlib.js.20250909_204604

=== Inserting information retrieval code ===
[info] Sensors' retriever added to "/usr/share/perl5/PVE/API2/Nodes.pm".
[info] UPS retriever added to "/usr/share/perl5/PVE/API2/Nodes.pm".
[info] System information retriever added to "/usr/share/perl5/PVE/API2/Nodes.pm".

=== Creating temperature conversion helper ===
[info] Temperature helper configured for C.

=== Expanding StatusView space ===
[info] Expanded space in "/usr/share/pve-manager/js/pvemanagerlib.js".

=== Inserting temperature helper ===
[info] Temperature helper inserted successfully.

=== Making visual adjustments ===
[info] Inserted system_info widget.
[info] Inserted ups widget.
[info] Inserted fan widget.
[info] Inserted ram widget.
[info] Inserted cpu widget.
[info] Added visual separator for modified items.
[info] Node summary box moved into its own container.

=== Finalizing installation ===
[info] Restarting PVE proxy...
[info] Installation completed.

Clear the browser cache to ensure all changes are visualized. (any key to continue):

```

Task:

- [x]  flat json

- [x]  pretty jason
