### PR TITLE
feat: NVIDIA GPU temperature support (thermalGpu widget)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,66 @@
+# Improvements in this fork
+
+This branch (`feature/nvidia-gpu-temps`) adds NVIDIA GPU temperature support
+to [`Meliox/PVE-mods`](https://github.com/Meliox/PVE-mods)'s
+`pve-mod-gui-sensors.sh`.
+
+---
+
+## 1. NVIDIA GPU temperature widget (`thermalGpu`)
+
+**File**: `pve-mod-gui-sensors.sh`
+
+Two additions to the install script:
+
+### a) Sensor JSON injection
+
+When `nvidia-smi` is present on the host, inject one entry per GPU into
+`Nodes.pm`'s `$res->{sensorsOutput}` JSON before the existing
+`lm-sensors` payload:
+
+```json
+"GPU0 RTX 3090": {
+  "Adapter": "NVIDIA",
+  "GPU Core": { "temp1_input": 47.0 }
+}
+```
+
+Each GPU appears as `GPU<idx> <model>` (with the `NVIDIA GeForce ` prefix
+stripped). Calls `nvidia-smi --query-gpu=index,name,temperature.gpu` once
+per request.
+
+### b) ExtJS `thermalGpu` widget
+
+Adds a new widget under the StatusView that filters sensor keys starting
+with `GPU` and renders each as `GPU<idx>:&nbsp;<temp>°C` with the
+existing TempHelper (Fahrenheit conversion supported).
+
+Color thresholds:
+- ≥ 85 °C — yellow / bold
+- ≥ 95 °C — red / bold
+
+The widget is only emitted when the install script's GPU detection
+succeeds, so non-NVIDIA hosts behave exactly like upstream.
+
+---
+
+## How to install this fork
+
+```bash
+wget https://raw.githubusercontent.com/svilendotorg/PVE-mods/feature/nvidia-gpu-temps/pve-mod-gui-sensors.sh
+bash pve-mod-gui-sensors.sh install
+```
+
+Then clear your browser cache and reload the Proxmox web UI. The new
+"GPU Thermal State" row appears in the node summary.
+
+To track upstream:
+
+```bash
+git clone https://github.com/svilendotorg/PVE-mods
+cd PVE-mods
+git remote add upstream https://github.com/Meliox/PVE-mods.git
+git fetch upstream
+git rebase upstream/main
+git push --force-with-lease
+```

--- a/pve-mod-gui-sensors.sh
+++ b/pve-mod-gui-sensors.sh
@@ -239,6 +239,25 @@ function configure {
     fi
 	#endregion nvme setup
 
+    #### NVIDIA GPU ####
+    #region gpu setup
+    msgb "\n=== Detecting NVIDIA GPUs ==="
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        local gpuList=($(nvidia-smi --query-gpu=index,name --format=csv,noheader 2>/dev/null | sed 's/, /,/' | sed 's/ /_/g'))
+        if [ ${#gpuList[@]} -gt 0 ]; then
+            info "Detected NVIDIA GPUs (${#gpuList[@]}): $(IFS=,; echo "${gpuList[*]}")"
+            ENABLE_GPU_TEMP=true
+            SENSORS_DETECTED=true
+        else
+            warn "nvidia-smi found but no GPUs detected."
+            ENABLE_GPU_TEMP=false
+        fi
+    else
+        warn "nvidia-smi not present, skipping NVIDIA GPU detection."
+        ENABLE_GPU_TEMP=false
+    fi
+    #endregion gpu setup
+
 	#### Fans ####
 	#region fan setup
 	msgb "\n=== Detecting fan speed sensors ==="
@@ -416,6 +435,7 @@ function install_mod {
     fi
 
     generate_and_insert_widget "$ENABLE_FAN_SPEED" "generate_fan_widget" "fan"
+    generate_and_insert_widget "$ENABLE_GPU_TEMP" "generate_gpu_widget" "gpu"
     generate_and_insert_widget "$ENABLE_RAM_TEMP" "generate_ram_widget" "ram"
     generate_and_insert_widget "$ENABLE_CPU" "generate_cpu_widget" "cpu"
 
@@ -520,6 +540,30 @@ collect_sensors_output() {
 		$res->{sensorsOutput} = `echo \\Q$1\\E | python3 -m json.tool 2>/dev/null || echo \\Q$1\E`;\
 	' "$NODES_PM_FILE"
 	#endregion sensors heredoc
+
+	# NVIDIA GPU temps — separate sed block so it can be enabled independently.
+	if [ "$ENABLE_GPU_TEMP" = true ]; then
+		#region gpu heredoc
+		sed -i '/my \$dinfo = df('\''\/'\'', 1);/i\
+		# Add NVIDIA GPU temperatures (injected by pve-mod-gui-sensors.sh)\
+		my $gpu_out = `nvidia-smi --query-gpu=index,name,temperature.gpu --format=csv,noheader 2>/dev/null`;\
+		if ($gpu_out) {\
+			my $gpu_json = "";\
+			for my $line (split /\\n/, $gpu_out) {\
+				$line =~ s/^\\s+|\\s+$//g;\
+				next unless $line;\
+				my ($idx, $name, $temp) = split /,\\s*/, $line;\
+				$name =~ s/NVIDIA GeForce //;\
+				$gpu_json .= "\\"GPU$idx $name\\": {\\"Adapter\\": \\"NVIDIA\\", \\"GPU Core\\": {\\"temp1_input\\": $temp.0}},\\n";\
+			}\
+			if ($gpu_json) {\
+				$res->{sensorsOutput} =~ s/^\\s*\\{/\\{$gpu_json/;\
+			}\
+		}\
+		' "$NODES_PM_FILE"
+		#endregion gpu heredoc
+		info "GPU temperature retriever added to \"$NODES_PM_FILE\"."
+	fi
     info "Sensors' retriever added to \"$output_file\"."
 }
 
@@ -700,6 +744,8 @@ add_visual_separator() {
 
     if [ "$ENABLE_UPS" = true ]; then
         lastItemId="upsc"
+    elif [ "$ENABLE_GPU_TEMP" = true ]; then
+        lastItemId="thermalGpu"
     elif [ "$ENABLE_HDD_TEMP" = true ]; then
         lastItemId="thermalHdd"
     elif [ "$ENABLE_NVME_TEMP" = true ]; then
@@ -1109,6 +1155,57 @@ EOF
         echo "Error: Failed to generate nvme widget code" >&2
         exit 1
     fi
+}
+
+# Function to generate NVIDIA GPU widget
+generate_gpu_widget() {
+	#region gpu widget heredoc
+	(
+		export HELPERCTORPARAMS
+		cat <<'EOF' | envsubst '$HELPERCTORPARAMS' > "$1"
+		{
+			itemId: 'thermalGpu',
+			colspan: 2,
+			printBar: false,
+			title: gettext('GPU Thermal State'),
+			iconCls: 'fa fa-fw fa-thermometer-half',
+			textField: 'sensorsOutput',
+			renderer: function(value) {
+				const tempHelper = Ext.create('PVE.mod.TempHelper', $HELPERCTORPARAMS);
+				let objValue;
+				try { objValue = JSON.parse(value) || {}; } catch(e) { objValue = {}; }
+				const gpuKeys = Object.keys(objValue).filter(item => String(item).startsWith('GPU')).sort();
+				if (gpuKeys.length === 0) return 'N/A';
+				let temps = [];
+				gpuKeys.forEach((gpuKey) => {
+					try {
+						const gpuData = objValue[gpuKey];
+						const coreKeys = Object.keys(gpuData).filter(k => k !== 'Adapter');
+						coreKeys.forEach((coreKey) => {
+							let tempVal = NaN;
+							Object.keys(gpuData[coreKey]).forEach((secondKey) => {
+								if (secondKey.endsWith('_input')) {
+									tempVal = tempHelper.getTemp(parseFloat(gpuData[coreKey][secondKey]));
+								}
+							});
+							if (!isNaN(tempVal)) {
+								const tempStyle = tempVal >= 85 ? 'color: #FFC300; font-weight: bold;' : tempVal >= 95 ? 'color: red; font-weight: bold;' : '';
+								temps.push(`${gpuKey}:&nbsp;<span style="${tempStyle}">${Ext.util.Format.number(tempVal, '0')}${tempHelper.getUnit()}</span>`);
+							}
+						});
+					} catch(e) { /*_*/ }
+				});
+				const result = temps.join('&nbsp;| ');
+				return '<div style="text-align: left; margin-left: 28px;">' + (result.length > 0 ? result : 'N/A') + '</div>';
+			}
+		},
+EOF
+	)
+	#endregion gpu widget heredoc
+	if [[ $? -ne 0 ]]; then
+		echo "Error: Failed to generate gpu widget code" >&2
+		exit 1
+	fi
 }
 
 # Function to generate Fan widget

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,9 @@
+> **🍴 Fork notice** — this is a downstream fork of [Meliox/PVE-mods](https://github.com/Meliox/PVE-mods).
+> Default branch [`feature/nvidia-gpu-temps`](https://github.com/svilendotorg/PVE-mods/tree/feature/nvidia-gpu-temps) adds NVIDIA GPU temperature support to `pve-mod-gui-sensors.sh` (sensor-JSON injection + `thermalGpu` ExtJS widget on the node summary).
+> See [**IMPROVEMENTS.md**](IMPROVEMENTS.md) for the full list of downstream changes and rationale.
+
+---
+
 # Proxmox Virtual Environment mods and scripts
 A small collection of scripts and mods for Proxmox Virtual Environment (PVE)
 


### PR DESCRIPTION
## What

Adds an optional NVIDIA GPU temperature row to the Proxmox node summary, in the same style as the existing CPU / NVMe / HDD widgets. Activated automatically when `nvidia-smi` is present on the host; left untouched otherwise — non-NVIDIA hosts behave exactly like upstream.

Two additions to `pve-mod-gui-sensors.sh`:

### 1. Sensor JSON injection (Perl side)

When `nvidia-smi` is available, inject one entry per GPU into the JSON `Nodes.pm` returns as `$res->{sensorsOutput}`:

```json
"GPU0 RTX 3090": {
  "Adapter": "NVIDIA",
  "GPU Core": { "temp1_input": 47.0 }
}
```

Each GPU is keyed `GPU<idx> <model>` (with the `NVIDIA GeForce ` prefix stripped). Backed by a single `nvidia-smi --query-gpu=index,name,temperature.gpu` call per request.

### 2. `thermalGpu` ExtJS widget

A new widget in the StatusView that filters keys starting with `GPU`, sorts them, and renders each as `GPUN: <temp>°C` using the existing `TempHelper` (so the Fahrenheit conversion path keeps working).

Color thresholds:
- ≥ 85 °C → yellow / bold
- ≥ 95 °C → red / bold

## Why

I have a Proxmox node with two RTX 3090s running mixed AI workloads (vLLM, ComfyUI, etc.). The existing CPU / NVMe widgets are great, but I had no equivalent for GPU thermals on the node summary — the only signal was opening a shell and running `nvidia-smi`. This widget gives an at-a-glance view in the same format as everything else `pve-mod-gui-sensors.sh` already provides.

## Compatibility

- **Hosts without `nvidia-smi`**: detection block skips the widget entirely; install script behaves exactly as before. No new dependencies.
- **Hosts with NVIDIA GPUs**: requires `nvidia-smi` (already standard on any Proxmox box with GPU passthrough).
- **Existing temperature widgets** (CPU / NVMe / HDD / fans): unchanged.
- **Existing layout / styling**: matches.

## Tested

Proxmox VE 8.x, dual RTX 3090, NVIDIA driver 595.58.03 — widget appears in node summary, updates on the regular sensor poll, color thresholds trigger at the right values.

## Notes

The fork at [svilendotorg/PVE-mods](https://github.com/svilendotorg/PVE-mods/tree/feature/nvidia-gpu-temps) carries this single change; full description in [IMPROVEMENTS.md](https://github.com/svilendotorg/PVE-mods/blob/feature/nvidia-gpu-temps/IMPROVEMENTS.md).