### PR TITLE
fix(node_info): normalize UPS data — derive ups.realpower fallback and clean invalid battery.mfr.date

### DIFF
--- a/src/modules/node_info/files/Collector/Ups.pm
+++ b/src/modules/node_info/files/Collector/Ups.pm
@@ -112,6 +112,8 @@ sub _parse_upsc_output {
                 }
             }
         }
+
+        _normalize_ups_data($ups_data);
     };
     if ($@) {
         debug(__LINE__, "Error parsing upsc output: $@");
@@ -120,6 +122,30 @@ sub _parse_upsc_output {
     debug(__LINE__, "Completed parsing upsc output");
 
     return $ups_data;
+}
+
+# ============================================================================
+# UPS — data normalization
+# ============================================================================
+
+sub _normalize_ups_data {
+    my ($ups_data) = @_;
+
+    # Some devices report a placeholder (e.g. "OPEN") instead of a real date
+    if (defined $ups_data->{'battery.mfr.date'} && $ups_data->{'battery.mfr.date'} !~ m{^\d{4}[/-]\d{1,2}[/-]\d{1,2}$}) {
+        delete $ups_data->{'battery.mfr.date'};
+    }
+
+    # Derive real power draw for devices that don't report ups.realpower directly
+    if (!defined $ups_data->{'ups.realpower'}) {
+        if (defined $ups_data->{'ups.load'} && defined $ups_data->{'ups.realpower.nominal'}) {
+            $ups_data->{'ups.realpower'} = int((($ups_data->{'ups.load'} / 100) * $ups_data->{'ups.realpower.nominal'}) + 0.5);
+        } elsif (defined $ups_data->{'output.current'} && defined $ups_data->{'output.voltage'}) {
+            $ups_data->{'ups.realpower'} = int(($ups_data->{'output.current'} * $ups_data->{'output.voltage'}) + 0.5);
+        }
+    }
+
+    return;
 }
 
 1;

--- a/src/modules/node_info/files/PveMod_pvemanagerlib.js
+++ b/src/modules/node_info/files/PveMod_pvemanagerlib.js
@@ -969,7 +969,7 @@ Ext.define('PVE.node.StatusView', {
                     const testResult = upsData['ups.test.result'];
                     const batteryChargeLow = upsData['battery.charge.low'];
                     const batteryRuntimeLow = upsData['battery.runtime.low'];
-                    const upsRealPowerNominal = upsData['ups.realpower.nominal'];
+                    const upsRealPower = upsData['ups.realpower'];
                     const batteryMfrDate = upsData['battery.mfr.date'];
 
                     // Main status line with all metrics
@@ -1046,12 +1046,8 @@ Ext.define('PVE.node.StatusView', {
                     // Calculate actual watt usage
                     if (statusLine) statusLine += ' | ';
                     let actualWattage = null;
-                    if (upsLoad && upsRealPowerNominal) {
-                        const load = parseFloat(upsLoad);
-                        const nominal = parseFloat(upsRealPowerNominal);
-                        if (!isNaN(load) && !isNaN(nominal)) {
-                            actualWattage = Math.round((load / 100) * nominal);
-                        }
+                    if (upsRealPower && !isNaN(parseFloat(upsRealPower))) {
+                        actualWattage = Math.round(parseFloat(upsRealPower));
                     }
 
                     // Real power (calculated watt usage)


### PR DESCRIPTION
fix #138 