### PR TITLE
fix(node_info): hide GPU Details and GPU Fans when no GPU is present

### DIFF
--- a/src/modules/node_info/files/PveMod_pvemanagerlib.js
+++ b/src/modules/node_info/files/PveMod_pvemanagerlib.js
@@ -391,6 +391,7 @@ Ext.define('PVE.node.StatusView', {
                     this.hide();
                     return '';
                 } else if (!gpuStats || !gpuStats.Graphics) {
+                    this.hide();
                     return '';
                 }
 
@@ -508,9 +509,12 @@ Ext.define('PVE.node.StatusView', {
                 }
 
                 html += '</table>';
-                return html.indexOf('<tr>') > 0
-                    ? '<div style="padding-left: 20px; box-sizing: border-box;">' + html + '</div>'
-                    : '';
+                if (html.indexOf('<tr>') <= 0) {
+                    this.hide();
+                    return '';
+                }
+                this.show();
+                return '<div style="padding-left: 20px; box-sizing: border-box;">' + html + '</div>';
             },
         },
         {
@@ -865,6 +869,7 @@ Ext.define('PVE.node.StatusView', {
                     this.hide();
                     return '';
                 } else if (!gpuStats || !gpuStats.Graphics || !gpuStats.Graphics.NVIDIA) {
+                    this.hide();
                     return '';
                 }
 
@@ -892,8 +897,10 @@ Ext.define('PVE.node.StatusView', {
                 });
                 
                 if (rows.length === 0) {
+                    this.hide();
                     return '';
                 }
+                this.show();
 
                 return '<div style="padding-left: 20px; box-sizing: border-box;"><table style="width: 100%; border-collapse: collapse; table-layout: fixed;">' + rows.join('') + '</table></div>';
             },


### PR DESCRIPTION
Split out of #310 as requested.

On nodes without a GPU, `PveMod_graphicsInfo` is empty (`{}` or no `Graphics` entries). The renderers returned an empty string but did not hide the widget, so **GPU Details** / **GPU Fans** still showed as labelled rows.

This calls `this.hide()` when there is nothing to render, and `this.show()` when there is.