### PR TITLE
feat(node_info): add configurable mod_debug toggle for debug logging

### DIFF
--- a/src/modules/node_info/files/Config.pm
+++ b/src/modules/node_info/files/Config.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(
 # Debug / Version
 # ============================================================================
 
-our $DEBUG_ENABLED = 1;
+our $DEBUG_ENABLED;  # derived from %config{debug}{mod_debug} after ini load, below
 our $VERSION       = 'version-placeholder';
 
 # ============================================================================
@@ -43,6 +43,7 @@ our %config = (
         gpu_history    => 0,
     },
     debug => {
+        mod_debug              => 0,
         log_enabled            => 0,
         log_file               => '/tmp/pve-mod-debug.log',
         lm_sensors_mode        => 0,
@@ -158,5 +159,7 @@ sub _load_ini_file {
 
 _load_ini_file($CONF_FILE);
 _load_ini_file($_) for glob("$CONFD_DIR/*.conf");
+
+$DEBUG_ENABLED = $config{debug}{mod_debug};
 
 1;

--- a/src/modules/node_info/node_info.conf
+++ b/src/modules/node_info/node_info.conf
@@ -30,7 +30,11 @@ ignore_temp_below=5
 
 # Debug mode: when a collector's mode is 1, the real tool is not required.
 # Data is read from the file path instead. Useful for development/testing.
+# Note: debug settings are only read at pveproxy startup — restart pveproxy
+# after changing them. Debug output goes to the journal (journalctl -u pveproxy),
+# plus log_file if log_enabled=1.
 [debug]
+mod_debug=0
 lm_sensors_mode=0
 lm_sensors_output_file=/tmp/sensors-output.json
 intel_mode=0

--- a/src/modules/node_info/node_info.configure.sh
+++ b/src/modules/node_info/node_info.configure.sh
@@ -78,6 +78,7 @@ node_info_defaults() {
     DEBUG_AMD=0;         DEBUG_AMD_FILE="/tmp/amd-gpu-devices.json"
     DEBUG_UPS=0;         DEBUG_UPS_FILE="/tmp/ups-output.json"
     DEBUG_LOG=0;         DEBUG_LOG_FILE="/tmp/pve-mod-debug.log"
+    DEBUG_MOD=0
 }
 
 node_info_load_conf() {
@@ -124,6 +125,7 @@ node_info_load_conf() {
             debug.ups_output_file)          DEBUG_UPS_FILE="$val" ;;
             debug.log_enabled)              DEBUG_LOG="$val" ;;
             debug.log_file)                 DEBUG_LOG_FILE="$val" ;;
+            debug.mod_debug)                DEBUG_MOD="$val" ;;
         esac
     done < "$NODE_INFO_CONF"
 }
@@ -512,7 +514,11 @@ ignore_temp_below=${IGNORE_TEMP_BELOW}
 
 # Debug mode: when a collector's mode is 1, the real tool is not required.
 # Data is read from the file path instead. Useful for development/testing.
+# Note: debug settings are only read at pveproxy startup — restart pveproxy
+# after changing them. Debug output goes to the journal (journalctl -u pveproxy),
+# plus log_file if log_enabled=1.
 [debug]
+mod_debug=${DEBUG_MOD}
 lm_sensors_mode=${DEBUG_LM_SENSORS}
 lm_sensors_output_file=${DEBUG_LM_SENSORS_FILE}
 intel_mode=${DEBUG_INTEL}

--- a/src/modules/node_info/readme.md
+++ b/src/modules/node_info/readme.md
@@ -67,3 +67,27 @@ Each feature requires the corresponding tool to be installed on the Proxmox host
 ## Debug Mode
 
 Each collector supports a debug mode that reads from a local file instead of executing the real tool. Useful for development and testing without physical hardware.
+
+### Per-collector debug files
+
+Set the collector's `_mode` flag to `1` in the `[debug]` section of `/etc/pve-mod/conf.d/node_info.conf` and populate its file(s) with sample data, captured from a real host via the commands below:
+
+| Collector | Enable flag | File | Content | Example to generate it |
+|-----------|-------------|------|---------|-------------------------|
+| Temperature sensors | `lm_sensors_mode` | `lm_sensors_output_file` | Raw `sensors -j` JSON output | `sensors -j > /tmp/sensors-output.json` |
+| Intel GPU | `intel_mode` | `intel_devices_file` | Device list, one line per GPU (`intel_gpu_top -L` format) | `intel_gpu_top -L > /tmp/intel-gpu-devices.json` |
+| | | `intel_output_file` | Continuous `intel_gpu_top` stats output | `intel_gpu_top -d /dev/dri/card0 -s 1000 -l > /tmp/intel-gpu-output.txt` |
+| NVIDIA GPU | `nvidia_mode` | `nvidia_devices_file` | Device list CSV | `nvidia-smi --query-gpu=index,name --format=csv > /tmp/nvidia-smi-devices.csv` |
+| | | `nvidia_output_file` | Stats CSV | `nvidia-smi --query-gpu=index,name,temperature.gpu,utilization.gpu,utilization.memory,memory.used,memory.total,power.draw,power.limit,fan.speed --format=csv,nounits > /tmp/nvidia-smi-output.csv` |
+| AMD GPU | `amd_mode` | `amd_devices_file` | Placeholder — collector not yet implemented | — |
+| UPS | `ups_mode` | `ups_output_file` | Raw `upsc` key: value output (despite the `.json` name, it's plain text, not JSON) | `upsc ups@192.168.1.50 > /tmp/ups-output.json` |
+
+### Verbose module logging (mod_debug)
+
+Set `mod_debug=1` in the `[debug]` section of `/etc/pve-mod/conf.d/node_info.conf`, then restart `pveproxy` (`systemctl restart pveproxy`) — the setting is only read at startup. With it enabled, the mod logs each internal step (collector start/stop, cache hits, file reads, etc.) to the journal, viewable with:
+
+```sh
+journalctl -u pveproxy -f
+```
+
+Set `log_enabled=1` (and optionally `log_file`) in the same section to also persist this output to a file.


### PR DESCRIPTION
fix #321 

Adds a mod_debug option to the node_info module's [debug] config section, replacing the previously hardcoded $DEBUG_ENABLED = 1 in Config.pm.

Config.pm: $DEBUG_ENABLED is now derived from %config{debug}{mod_debug} after the ini file is merged, instead of being hardcoded on.
node_info.conf: adds mod_debug=0 (default off) to [debug], with a note that changes require a pveproxy restart and that debug output goes to the journal (journalctl -u pveproxy), plus log_file if log_enabled=1.
node_info.configure.sh: wires DEBUG_MOD through node_info_defaults, node_info_load_conf, and node_info_write_conf so the setting round-trips through the configuration wizard.